### PR TITLE
fix quote-escaping for turtle xsd:string formatting (previous impl fails on multiline-strings ending with a quote) 

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+language: "en"
+early_access: false
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: true
+chat:
+  auto_reply: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -660,18 +660,18 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "filelock"
-version = "3.16.0"
+version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
-    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.3)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
@@ -713,14 +713,17 @@ lxml = ["lxml"]
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "imagesize"
@@ -735,22 +738,26 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "8.4.0"
+version = "8.5.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-8.4.0-py3-none-any.whl", hash = "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1"},
-    {file = "importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"},
+    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
+    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
 ]
 
 [package.dependencies]
-zipp = ">=0.5"
+zipp = ">=3.20"
 
 [package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
+type = ["pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -1251,13 +1258,13 @@ testing = ["pytest", "pytest-cov", "wheel"]
 
 [[package]]
 name = "platformdirs"
-version = "4.3.2"
+version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.3.2-py3-none-any.whl", hash = "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"},
-    {file = "platformdirs-4.3.2.tar.gz", hash = "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c"},
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [package.extras]
@@ -2015,13 +2022,13 @@ files = [
 
 [[package]]
 name = "trove-classifiers"
-version = "2024.7.2"
+version = "2024.9.12"
 description = "Canonical source for classifiers on PyPI (pypi.org)."
 optional = false
 python-versions = "*"
 files = [
-    {file = "trove_classifiers-2024.7.2-py3-none-any.whl", hash = "sha256:ccc57a33717644df4daca018e7ec3ef57a835c48e96a1e71fc07eb7edac67af6"},
-    {file = "trove_classifiers-2024.7.2.tar.gz", hash = "sha256:8328f2ac2ce3fd773cbb37c765a0ed7a83f89dc564c7d452f039b69249d0ac35"},
+    {file = "trove_classifiers-2024.9.12-py3-none-any.whl", hash = "sha256:f88a27a892891c87c5f8bbdf110710ae9e0a4725ea8e0fb45f1bcadf088a491f"},
+    {file = "trove_classifiers-2024.9.12.tar.gz", hash = "sha256:4b46b3e134a4d01999ac5bc6e528afcc10cc48f0f724f185f267e276005768f4"},
 ]
 
 [[package]]
@@ -2094,13 +2101,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
+    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
 
 [package.extras]
@@ -2139,13 +2146,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.26.4"
+version = "20.26.5"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.4-py3-none-any.whl", hash = "sha256:48f2695d9809277003f30776d155615ffc11328e6a0a8c1f0ec80188d7874a55"},
-    {file = "virtualenv-20.26.4.tar.gz", hash = "sha256:c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c"},
+    {file = "virtualenv-20.26.5-py3-none-any.whl", hash = "sha256:4f3ac17b81fba3ce3bd6f4ead2749a72da5929c01774948e243db9ba41df4ff6"},
+    {file = "virtualenv-20.26.5.tar.gz", hash = "sha256:ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4"},
 ]
 
 [package.dependencies]
@@ -2312,13 +2319,13 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.20.1"
+version = "3.20.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.20.1-py3-none-any.whl", hash = "sha256:9960cd8967c8f85a56f920d5d507274e74f9ff813a0ab8889a5b5be2daf44064"},
-    {file = "zipp-3.20.1.tar.gz", hash = "sha256:c22b14cc4763c5a5b04134207736c107db42e9d3ef2d9779d465f5f1bcba572b"},
+    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
+    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
 ]
 
 [package.extras]

--- a/sema/commons/j2/j2_functions.py
+++ b/sema/commons/j2/j2_functions.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 from datetime import date, datetime
 
 from dateutil import parser
-from rdflib import Literal
 from uritemplate import URITemplate
 
 from sema.commons.clean import clean_uri_str
@@ -103,7 +102,8 @@ def xsd_format_string(content, quote, suffix):
     # fmt: off
     # do a regex replce of axectly \\ or ' or " to \\\\ or \' or \"
     # not regular replace since we don't want \n to be replaced
-    content = re.sub(r"\\(?=" + re.escape(quote) + r")", lambda m: "\\" + m.group(), str(content))
+    content = re.sub(r"\\(?=" + re.escape(quote) + r")",
+                     lambda m: "\\" + m.group(), str(content))
 
     # fmt: on
     if "\n" in content or quote in content:

--- a/sema/commons/j2/j2_functions.py
+++ b/sema/commons/j2/j2_functions.py
@@ -109,7 +109,6 @@ def xsd_format_string(content, quote, suffix):
     if "\n" in content or quote in content:
         content = content.replace(quote, "\\" + quote)
         quote = quote * 3  # make long quote variant
-        # make sure that the quote is escaped in the content
     assert quote not in content, (
         "ttl format error: still having "
         f"applied quote format {quote} in text content"

--- a/sema/commons/j2/j2_functions.py
+++ b/sema/commons/j2/j2_functions.py
@@ -100,9 +100,16 @@ def xsd_format_uri(content, quote, suffix):
 
 def xsd_format_string(content, quote, suffix):
     # deal with escapes -- note: uses rdflib implementation
-    content = Literal(str(content)).n3()
+    # fmt: off
+    # do a regex replce of axectly \\ or ' or " to \\\\ or \' or \"
+    # not regular replace since we don't want \n to be replaced
+    content = re.sub(r"\\(?=" + re.escape(quote) + r")", lambda m: "\\" + m.group(), str(content))
+
+    # fmt: on
     if "\n" in content or quote in content:
+        content = content.replace(quote, "\\" + quote)
         quote = quote * 3  # make long quote variant
+        # make sure that the quote is escaped in the content
     assert quote not in content, (
         "ttl format error: still having "
         f"applied quote format {quote} in text content"

--- a/sema/commons/j2/j2_functions.py
+++ b/sema/commons/j2/j2_functions.py
@@ -98,20 +98,17 @@ def xsd_format_uri(content, quote, suffix):
 
 
 def xsd_format_string(content, quote, suffix):
-    # fmt: off
-    # do a regex replce of axectly \\ or ' or " to \\\\ or \' or \"
-    # not regular replace since we don't want \n to be replaced
-    content = re.sub(r"\\(?=" + re.escape(quote) + r")",
-                     lambda m: "\\" + m.group(), str(content))
+    # apply escape sequences: \ to \\ and quote to \quote
+    escqt = f"\\{quote}"
+    content = str(content).replace("\\", "\\\\").replace(quote, escqt)
 
-    # fmt: on
-    if "\n" in content or quote in content:
-        quote = quote * 3  # make long quote variant
-    assert quote not in content, (
-        "ttl format error: still having "
-        f"quote {quote} in text content {content}"
-        f"applied quote format {quote} in text content"
-    )
+    if "\n" in content:
+        quote = quote * 3  # make long quote variant to allow for newlines
+        assert quote not in content, (
+            "ttl format error: still having "
+            f"quote {quote} in text content {content}"
+            f"applied quote format {quote} in text content"
+        )
     return xsd_value(content, quote, "xsd:string", suffix)
 
 

--- a/sema/commons/j2/j2_functions.py
+++ b/sema/commons/j2/j2_functions.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from datetime import date, datetime
 
 from dateutil import parser
+from rdflib import Literal
 from uritemplate import URITemplate
 
 from sema.commons.clean import clean_uri_str
@@ -98,18 +99,10 @@ def xsd_format_uri(content, quote, suffix):
 
 
 def xsd_format_string(content, quote, suffix):
-    # deal with escapes -- note: code is odd to read,
-    #   but this escapes single \ to double \\
-    content = str(content).replace("\\", "\\\\")
+    # deal with escapes -- note: uses rdflib implementation
+    content = Literal(str(content)).n3()
     if "\n" in content or quote in content:
-        triplus_pattern = r"([']{3}[']*)" if quote == "'" else r'(["]{3}["]*)'
-        esc_qt = "\\" + quote  # escaped quote
         quote = quote * 3  # make long quote variant
-        content = re.sub(
-            triplus_pattern,  # find sequences of 3 or more quotes...
-            lambda x: esc_qt * len(x.group()),  # and have each of them escaped
-            content,  # so all ''' should become \'\'\' in the content
-        )
     assert quote not in content, (
         "ttl format error: still having "
         f"applied quote format {quote} in text content"

--- a/sema/commons/j2/j2_functions.py
+++ b/sema/commons/j2/j2_functions.py
@@ -98,7 +98,6 @@ def xsd_format_uri(content, quote, suffix):
 
 
 def xsd_format_string(content, quote, suffix):
-    # deal with escapes -- note: uses rdflib implementation
     # fmt: off
     # do a regex replce of axectly \\ or ' or " to \\\\ or \' or \"
     # not regular replace since we don't want \n to be replaced
@@ -107,10 +106,10 @@ def xsd_format_string(content, quote, suffix):
 
     # fmt: on
     if "\n" in content or quote in content:
-        content = content.replace(quote, "\\" + quote)
         quote = quote * 3  # make long quote variant
     assert quote not in content, (
         "ttl format error: still having "
+        f"quote {quote} in text content {content}"
         f"applied quote format {quote} in text content"
     )
     return xsd_value(content, quote, "xsd:string", suffix)

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -169,32 +169,27 @@ class TestXSDFormatting(unittest.TestCase):
             type_name = pfx + short_name
             self.assertEqual(
                 xsd_fmt("Hello!", type_name),
-                "'\"Hello!\"'^^xsd:string",
+                "'Hello!'^^xsd:string",
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt("'", type_name, quote='"'),
-                '""""\'""""^^xsd:string',
+                '"\'"^^xsd:string',
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt('"', type_name, quote="'"),
-                '\'"\\""\'^^xsd:string',
+                "'\"'^^xsd:string",
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt(">'<", type_name, quote="'"),
-                "'''\">'<\"'''^^xsd:string",
+                "'''>'<'''^^xsd:string",
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt(">\n<", type_name, quote="'"),
-                "'''\"\"\">\n<\"\"\"'''^^xsd:string",
-                "bad %s format" % type_name,
-            )
-            self.assertEqual(
-                xsd_fmt("'endind'", type_name, quote="'"),
-                "'''\"'endind'\"'''^^xsd:string",
+                "'''>\n<'''^^xsd:string",
                 "bad %s format" % type_name,
             )
 

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -182,11 +182,13 @@ class TestXSDFormatting(unittest.TestCase):
                 "'\"'^^xsd:string",
                 "bad %s format" % type_name,
             )
+            # fmt: off
             self.assertEqual(
                 xsd_fmt(">'<", type_name, quote="'"),
-                "'''>'<'''^^xsd:string",
+                "'''>\\'<'''^^xsd:string",
                 "bad %s format" % type_name,
             )
+            # fmt: on
             self.assertEqual(
                 xsd_fmt(">\n<", type_name, quote="'"),
                 "'''>\n<'''^^xsd:string",

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -183,6 +183,16 @@ class TestXSDFormatting(unittest.TestCase):
                 f"bad {type_name} format",
             )
             self.assertEqual(
+                xsd_fmt("'", type_name, quote="'"),
+                "'\\''^^xsd:string",
+                f"bad {type_name} format",
+            )
+            self.assertEqual(
+                xsd_fmt('"', type_name, quote='"'),
+                '"\\""^^xsd:string',
+                f"bad {type_name} format",
+            )
+            self.assertEqual(
                 xsd_fmt(">'<", type_name, quote="'"),
                 "'>\\'<'^^xsd:string",
                 f"bad {type_name} format",
@@ -205,13 +215,13 @@ class TestXSDFormatting(unittest.TestCase):
                 "bad language-string format",
             )
             self.assertEqual(
-                xsd_fmt("ceci n'est pas une texte", "@en"),
-                "'ceci n\\\'est pas une texte'^^xsd:string",
+                xsd_fmt("ceci n'est pas une texte", "@fr"),
+                "'ceci n\\\'est pas une texte'@fr",
                 "bad language-string formatting with quote-escapes",
             )
             self.assertEqual(
-                xsd_fmt("As \\  said before", "@en"),
-                "'As \\\\ said before'^^xsd:string",
+                xsd_fmt("As \\ said before", "@en"),
+                "'As \\\\ said before'@en",
                 "bad language-string formatting with backslash-escapes",
             )
 

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -170,29 +170,32 @@ class TestXSDFormatting(unittest.TestCase):
             self.assertEqual(
                 xsd_fmt("Hello!", type_name),
                 "'Hello!'^^xsd:string",
-                "bad %s format" % type_name,
+                f"bad {type_name} format",
             )
             self.assertEqual(
                 xsd_fmt("'", type_name, quote='"'),
                 '"\'"^^xsd:string',
-                "bad %s format" % type_name,
+                f"bad {type_name} format",
             )
             self.assertEqual(
                 xsd_fmt('"', type_name, quote="'"),
                 "'\"'^^xsd:string",
-                "bad %s format" % type_name,
+                f"bad {type_name} format",
             )
-            # fmt: off
             self.assertEqual(
                 xsd_fmt(">'<", type_name, quote="'"),
-                "'''>\'<'''^^xsd:string",
-                "bad %s format" % type_name,
+                "'>\\'<'^^xsd:string",
+                f"bad {type_name} format",
             )
-            # fmt: on
             self.assertEqual(
                 xsd_fmt(">\n<", type_name, quote="'"),
                 "'''>\n<'''^^xsd:string",
-                "bad %s format" % type_name,
+                f"bad {type_name} format",
+            )
+            self.assertEqual(
+                xsd_fmt(">\n<", type_name, quote='"'),
+                '""">\n<"""^^xsd:string',
+                f"bad {type_name} format",
             )
 
         def test_lang_string(self):
@@ -200,6 +203,16 @@ class TestXSDFormatting(unittest.TestCase):
                 xsd_fmt("Hello!", "@en"),
                 "'Hello!'@en",
                 "bad language-string format",
+            )
+            self.assertEqual(
+                xsd_fmt("ceci n'est pas une texte", "@en"),
+                "'ceci n\\\'est pas une texte'^^xsd:string",
+                "bad language-string formatting with quote-escapes",
+            )
+            self.assertEqual(
+                xsd_fmt("As \\  said before", "@en"),
+                "'As \\\\ said before'^^xsd:string",
+                "bad language-string formatting with backslash-escapes",
             )
 
 

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -169,27 +169,32 @@ class TestXSDFormatting(unittest.TestCase):
             type_name = pfx + short_name
             self.assertEqual(
                 xsd_fmt("Hello!", type_name),
-                "'Hello!'^^xsd:string",
+                "'\"Hello!\"'^^xsd:string",
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt("'", type_name, quote='"'),
-                '"\'"^^xsd:string',
+                '""""\'""""^^xsd:string',
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt('"', type_name, quote="'"),
-                "'\"'^^xsd:string",
+                '\'"\\""\'^^xsd:string',
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt(">'<", type_name, quote="'"),
-                "'''>'<'''^^xsd:string",
+                "'''\">'<\"'''^^xsd:string",
                 "bad %s format" % type_name,
             )
             self.assertEqual(
                 xsd_fmt(">\n<", type_name, quote="'"),
-                "'''>\n<'''^^xsd:string",
+                "'''\"\"\">\n<\"\"\"'''^^xsd:string",
+                "bad %s format" % type_name,
+            )
+            self.assertEqual(
+                xsd_fmt("'endind'", type_name, quote="'"),
+                "'''\"'endind'\"'''^^xsd:string",
                 "bad %s format" % type_name,
             )
 

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -185,7 +185,7 @@ class TestXSDFormatting(unittest.TestCase):
             # fmt: off
             self.assertEqual(
                 xsd_fmt(">'<", type_name, quote="'"),
-                "'''>\\'<'''^^xsd:string",
+                "'''>\'<'''^^xsd:string",
                 "bad %s format" % type_name,
             )
             # fmt: on

--- a/tests/commons/j2/test_j2_functions.py
+++ b/tests/commons/j2/test_j2_functions.py
@@ -216,7 +216,7 @@ class TestXSDFormatting(unittest.TestCase):
             )
             self.assertEqual(
                 xsd_fmt("ceci n'est pas une texte", "@fr"),
-                "'ceci n\\\'est pas une texte'@fr",
+                "'ceci n\\'est pas une texte'@fr",
                 "bad language-string formatting with quote-escapes",
             )
             self.assertEqual(

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -24,7 +24,7 @@ DIRECT_CASES: List[Tuple[str, str, int]] = [
     (
         "https://data.arms-mbon.org/",
         "text/turtle",
-        112,
+        115,
     ),
     (
         "https://data.arms-mbon.org/data_release_001/latest/#",

--- a/tests/subyt/in/data_schema.csv
+++ b/tests/subyt/in/data_schema.csv
@@ -8,4 +8,4 @@ y,"Longitude",xsd:double,geo:lon
 country,"Country",xsd:string,ex:country,
 txt_nl,"text in Dutch",@nl,ex:text,
 txt_fr,"text in French",@fr,ex:text,
-txt_en,"text in English",@en,ext:text,
+txt_en,"text in English",@en,ex:text,

--- a/tests/subyt/out/01-basic.ttl
+++ b/tests/subyt/out/01-basic.ttl
@@ -16,7 +16,7 @@
   schema:description '''een tekst over
 meerdere \'\'\'\'\'
 lijnen'''@nl;
-  schema:description '''ceci n'est pas une texte'''@fr;
+  schema:description 'ceci n\'est pas une texte'@fr;
   schema:description 'As \\ said before'@en;
   ex:posFirst 'true'^^xsd:boolean;
 

--- a/tests/subyt/out/01-basic.ttl
+++ b/tests/subyt/out/01-basic.ttl
@@ -16,8 +16,8 @@
   schema:description '''een tekst over
 meerdere \'\'\'\'\'
 lijnen'''@nl;
-  schema:description '''ceci n\'est pas une texte'''@fr;
-  schema:description 'As \ said before'@en;
+  schema:description '''ceci n'est pas une texte'''@fr;
+  schema:description 'As \\ said before'@en;
   ex:posFirst 'true'^^xsd:boolean;
 
   ex:position '0'^^xsd:integer.

--- a/tests/subyt/out/01-basic.ttl
+++ b/tests/subyt/out/01-basic.ttl
@@ -16,8 +16,8 @@
   schema:description '''een tekst over
 meerdere \'\'\'\'\'
 lijnen'''@nl;
-  schema:description '''ceci n'est pas une texte'''@fr;
-  schema:description 'As \\ said before'@en;
+  schema:description '''ceci n\'est pas une texte'''@fr;
+  schema:description 'As \ said before'@en;
   ex:posFirst 'true'^^xsd:boolean;
 
   ex:position '0'^^xsd:integer.

--- a/tests/subyt/out/09-mixedxml_no-it.ttl
+++ b/tests/subyt/out/09-mixedxml_no-it.ttl
@@ -1,5 +1,5 @@
 @prefix schema: <https://schema.org/>.
 
 [] schema:description 'One would think you have seen all the <em>sand</em> you could handle?'^^xsd:string.
-[] schema:description '''The major problem <span class="ed.d">[encountered in time travel]</span> is quite simply one of grammar, and the main work to consult in this matter is Dr. Dan Streetmentioner's Time Traveler's Handbook of 1001 Tense Formations.'''^^xsd:string.
+[] schema:description '''The major problem <span class="ed.d">[encountered in time travel]</span> is quite simply one of grammar, and the main work to consult in this matter is Dr. Dan Streetmentioner\'s Time Traveler\'s Handbook of 1001 Tense Formations.'''^^xsd:string.
 [] schema:description 'Makes you kind of think <b>twice</b> about displacing'^^xsd:string.

--- a/tests/subyt/out/09-mixedxml_no-it.ttl
+++ b/tests/subyt/out/09-mixedxml_no-it.ttl
@@ -1,5 +1,5 @@
 @prefix schema: <https://schema.org/>.
 
 [] schema:description 'One would think you have seen all the <em>sand</em> you could handle?'^^xsd:string.
-[] schema:description '''The major problem <span class="ed.d">[encountered in time travel]</span> is quite simply one of grammar, and the main work to consult in this matter is Dr. Dan Streetmentioner\'s Time Traveler\'s Handbook of 1001 Tense Formations.'''^^xsd:string.
+[] schema:description 'The major problem <span class="ed.d">[encountered in time travel]</span> is quite simply one of grammar, and the main work to consult in this matter is Dr. Dan Streetmentioner\'s Time Traveler\'s Handbook of 1001 Tense Formations.'^^xsd:string.
 [] schema:description 'Makes you kind of think <b>twice</b> about displacing'^^xsd:string.

--- a/tests/subyt/out/11-schemadriven.ttl
+++ b/tests/subyt/out/11-schemadriven.ttl
@@ -15,8 +15,8 @@
   ex:text '''een tekst over
 meerdere \'\'\'\'\'
 lijnen'''@nl;
-  ex:text '''ceci n'est pas une texte'''@fr;
-  ext:text 'As \\ said before'@en;
+  ex:text '''ceci n\'est pas une texte'''@fr;
+  ext:text 'As \ said before'@en;
 #----- 02
 @prefix ex: <https://example.org/11-schemadriven/> .
 @prefix dct: <http://purl.org/dc/terms> .

--- a/tests/subyt/out/11-schemadriven.ttl
+++ b/tests/subyt/out/11-schemadriven.ttl
@@ -15,8 +15,8 @@
   ex:text '''een tekst over
 meerdere \'\'\'\'\'
 lijnen'''@nl;
-  ex:text '''ceci n\'est pas une texte'''@fr;
-  ext:text 'As \\ said before'@en;
+  ex:text 'ceci n\'est pas une texte'@fr;
+  ex:text 'As \\ said before'@en;
 #----- 02
 @prefix ex: <https://example.org/11-schemadriven/> .
 @prefix dct: <http://purl.org/dc/terms> .

--- a/tests/subyt/out/11-schemadriven.ttl
+++ b/tests/subyt/out/11-schemadriven.ttl
@@ -16,7 +16,7 @@
 meerdere \'\'\'\'\'
 lijnen'''@nl;
   ex:text '''ceci n\'est pas une texte'''@fr;
-  ext:text 'As \ said before'@en;
+  ext:text 'As \\ said before'@en;
 #----- 02
 @prefix ex: <https://example.org/11-schemadriven/> .
 @prefix dct: <http://purl.org/dc/terms> .

--- a/tests/subyt/test_generator.py
+++ b/tests/subyt/test_generator.py
@@ -132,9 +132,9 @@ class TestJinjaGenerator(unittest.TestCase):
                     vars_dict={"my_domain": "realexample.org"},
                 )
             except Exception as e:
-                log.error(f"failed to process template: {e}")
                 log.exception(e)
-                raise e
+                log.exception("failed to process template")
+                raise
 
             # assure all records were passed
             sink.evaluate()

--- a/tests/subyt/test_generator.py
+++ b/tests/subyt/test_generator.py
@@ -123,13 +123,18 @@ class TestJinjaGenerator(unittest.TestCase):
             log.debug(
                 f"processing test-template: {os.path.join(tpl_path, name)}"
             )
-            g.process(
-                name,
-                inputs,
-                generator_settings,
-                sink,
-                vars_dict={"my_domain": "realexample.org"},
-            )
+            try:
+                g.process(
+                    name,
+                    inputs,
+                    generator_settings,
+                    sink,
+                    vars_dict={"my_domain": "realexample.org"},
+                )
+            except Exception as e:
+                log.error(f"failed to process template: {e}")
+                log.exception(e)
+                raise e
 
             # assure all records were passed
             sink.evaluate()


### PR DESCRIPTION
…irs, trove-classifiers, urllib3, virtualenv, and zipp packages  + fix j2 issue where xsd:string can return non synthax compliant triples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced string formatting for RDF literals using a refined approach, improving reliability and readability.

- **Bug Fixes**
	- Updated expected outputs in test cases for the `xsd_fmt` function to align with new string formatting logic, ensuring compliance with XML Schema Definition (XSD) requirements.
	- Corrected escape sequences in RDF Turtle files to maintain data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->