### PR TITLE
Fix/issue-134-cgi-dependency

### DIFF
--- a/sema/bench/core.py
+++ b/sema/bench/core.py
@@ -191,7 +191,8 @@ class Sembench(ServiceBase):
             except Exception as e:
                 log.error(
                     f"{task.task_id} in {self.sembench_config_path} "
-                    f"failed with exception: {e}")
+                    f"failed with exception: {e}"
+                )
                 if self.fail_fast:
                     log.error("Fail fast Mode enabled. Exiting.")
                     raise e

--- a/sema/commons/web/__init__.py
+++ b/sema/commons/web/__init__.py
@@ -1,7 +1,7 @@
+from .conneg import ConnegEvaluation, FoundVariants
+from .download_to_file import download_to_file, save_web_content
 from .httpsession import make_http_session
 from .parse_headers import get_parsed_header, parse_header
-from .download_to_file import download_to_file, save_web_content
-from .conneg import ConnegEvaluation, FoundVariants
 
 __all__ = [
     "make_http_session",

--- a/sema/commons/web/__init__.py
+++ b/sema/commons/web/__init__.py
@@ -1,6 +1,7 @@
-from .conneg import ConnegEvaluation, FoundVariants
-from .download_to_file import download_to_file, save_web_content
 from .httpsession import make_http_session
+from .parse_headers import get_parsed_header, parse_header
+from .download_to_file import download_to_file, save_web_content
+from .conneg import ConnegEvaluation, FoundVariants
 
 __all__ = [
     "make_http_session",
@@ -8,4 +9,6 @@ __all__ = [
     "FoundVariants",
     "download_to_file",
     "save_web_content",
+    "get_parsed_header",
+    "parse_header",
 ]

--- a/sema/commons/web/conneg.py
+++ b/sema/commons/web/conneg.py
@@ -1,4 +1,3 @@
-import cgi
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -19,6 +18,7 @@ from sema.commons.service import (
 
 from .download_to_file import save_web_content
 from .httpsession import make_http_session
+from .parse_headers import get_parsed_header
 
 log = getLogger(__name__)
 
@@ -40,12 +40,12 @@ class FoundVariants(ServiceResult, StatusMonitor):
         key = (mime_type or "", profile or "")
         assert key not in self.variants, f"Variant {key} already added"
         response_mime = (
-            cgi.parse_header(response.headers["Content-Type"])[0]
+            get_parsed_header(response.headers, "Content-Type")[0]
             if response
             else None
         )
-        cdispval, cdispparams = cgi.parse_header(
-            response.headers.get("Content-Disposition", "")  # type: ignore
+        cdispval, cdispparams = get_parsed_header(
+            response.headers, "Content-Disposition"  # type: ignore
         )
         cdispfile = (
             cdispparams.get("filename") if cdispval == "attachment" else None
@@ -197,7 +197,7 @@ SELECT ?mime ?profile WHERE {{
             log.debug(f"no variants detected for {self.url}")
             return
         # else
-        mime_type, options = cgi.parse_header(resp.headers["Content-Type"])
+        mime_type, options = get_parsed_header(resp.headers, "Content-Type")
         fmt = mime_to_format(mime_type)
         if fmt not in ["turtle", "n3", "json-ld"]:
             log.debug(f"unsupported format {fmt=} for {self.url}")

--- a/sema/commons/web/download_to_file.py
+++ b/sema/commons/web/download_to_file.py
@@ -1,5 +1,4 @@
 import base64
-import cgi
 import os
 from hashlib import sha256
 from pathlib import Path
@@ -9,6 +8,7 @@ from urllib.parse import urlparse
 from sema.commons.fileformats import suffix_for_mime
 
 from .httpsession import make_http_session
+from .parse_headers import get_parsed_header
 
 
 def download_to_file(
@@ -22,7 +22,7 @@ def download_to_file(
         dump_path=Path(dump_path),
         filename=filename,
         url=url,
-        mime_type=cgi.parse(response.headers.get("Content-Type"))[0],  # type: ignore # noqa
+        mime_type=get_parsed_header(response.headers, "Content-Type")[0],  # type: ignore # noqa
         profile=headers.get("Accept-profile", None),
         content=content,
     )

--- a/sema/commons/web/parse_headers.py
+++ b/sema/commons/web/parse_headers.py
@@ -1,7 +1,9 @@
 from email.message import EmailMessage
 
 
-def parse_header(content: str, mode: str = "content-type") -> tuple[str, dict[str, str]]:
+def parse_header(
+    content: str, mode: str = "content-type"
+) -> tuple[str, dict[str, str]]:
     # deal with empty content
     if content is None:
         return None, None
@@ -19,7 +21,8 @@ def parse_header(content: str, mode: str = "content-type") -> tuple[str, dict[st
     else:
         raise ValueError(
             "mode should be one of 'content-type' (default) "
-            "or 'content-disposition'")
+            "or 'content-disposition'"
+        )
     params = msg[mode].params
     return main, params
 

--- a/sema/commons/web/parse_headers.py
+++ b/sema/commons/web/parse_headers.py
@@ -1,0 +1,28 @@
+from email.message import EmailMessage
+
+
+def parse_header(content: str, mode: str = "content-type") -> tuple[str, dict[str, str]]:
+    # deal with empty content
+    if content is None:
+        return None, None
+    content = content.strip()
+    if not content:
+        return None, None
+    # deal with actual content
+    msg = EmailMessage()
+    mode = mode.lower()
+    msg[mode] = content
+    if mode == "content-type":
+        main = msg.get_content_type()
+    elif mode == "content-disposition":
+        main = msg.get_content_disposition()
+    else:
+        raise ValueError(
+            "mode should be one of 'content-type' (default) "
+            "or 'content-disposition'")
+    params = msg[mode].params
+    return main, params
+
+
+def get_parsed_header(headers, key) -> tuple[str, dict[str, str]]:
+    return parse_header(headers.get(key, None), key)

--- a/sema/discovery/discovery.py
+++ b/sema/discovery/discovery.py
@@ -10,7 +10,6 @@ from urllib3.exceptions import ResponseError
 
 from sema.commons.clean import check_valid_url
 from sema.commons.fileformats import format_from_filepath, mime_to_format
-from sema.commons.web import get_parsed_header
 from sema.commons.service import (
     ServiceBase,
     ServiceResult,
@@ -18,7 +17,11 @@ from sema.commons.service import (
     Trace,
 )
 from sema.commons.store import create_rdf_store
-from sema.commons.web import make_http_session, save_web_content
+from sema.commons.web import (
+    get_parsed_header,
+    make_http_session,
+    save_web_content,
+)
 
 from .linkheaders import extract_link_headers
 from .lod_html_parser import LODAwareHTMLParser
@@ -157,7 +160,9 @@ class Discovery(ServiceBase):
 
     def _extract_triples_from_response(self, resp: Response):
         # note we can be sure the response is ok, as we checked that before
-        resp_mime_type, options = get_parsed_header(resp.headers, "Content-Type")
+        resp_mime_type, options = get_parsed_header(
+            resp.headers, "Content-Type"
+        )
         if not resp_mime_type:
             log.debug(f"no content-type header in {resp.url=}")
             return

--- a/tests/commons/web/test_parse_headers.py
+++ b/tests/commons/web/test_parse_headers.py
@@ -1,15 +1,36 @@
 import pytest
+
 from sema.commons.web import parse_header
 
 
-@pytest.mark.parametrize("mode, content, expected_main, expected_params", [
-    ("content-type", "application/json", "application/json", {}),
-    ("content-type", 'text/plain; charset="utf8"', "text/plain", {"charset": "utf8"}),
-    ("content-type", 'main/subtype; key="value"; other="info"', "main/subtype", {"key": "value", "other": "info"}),
-    ("content-disposition", 'Attachment; filename="name.extension"', "attachment", {"filename": "name.extension"}),
-    ("content-type", "", None, None),
-],)
+@pytest.mark.parametrize(
+    "mode, content, expected_main, expected_params",
+    [
+        ("content-type", "application/json", "application/json", {}),
+        (
+            "content-type",
+            'text/plain; charset="utf8"',
+            "text/plain",
+            {"charset": "utf8"},
+        ),
+        (
+            "content-type",
+            'main/subtype; key="value"; other="info"',
+            "main/subtype",
+            {"key": "value", "other": "info"},
+        ),
+        (
+            "content-disposition",
+            'Attachment; filename="name.extension"',
+            "attachment",
+            {"filename": "name.extension"},
+        ),
+        ("content-type", "", None, None),
+    ],
+)
 def test_parse_headers(mode, content, expected_main, expected_params):
     main, params = parse_header(content, mode)
     assert main == expected_main, f"Expected {expected_main}, but got {main}"
-    assert params == expected_params, f"Expected {expected_params}, but got {params}"
+    assert (
+        params == expected_params
+    ), f"Expected {expected_params}, but got {params}"

--- a/tests/commons/web/test_parse_headers.py
+++ b/tests/commons/web/test_parse_headers.py
@@ -1,0 +1,15 @@
+import pytest
+from sema.commons.web import parse_header
+
+
+@pytest.mark.parametrize("mode, content, expected_main, expected_params", [
+    ("content-type", "application/json", "application/json", {}),
+    ("content-type", 'text/plain; charset="utf8"', "text/plain", {"charset": "utf8"}),
+    ("content-type", 'main/subtype; key="value"; other="info"', "main/subtype", {"key": "value", "other": "info"}),
+    ("content-disposition", 'Attachment; filename="name.extension"', "attachment", {"filename": "name.extension"}),
+    ("content-type", "", None, None),
+],)
+def test_parse_headers(mode, content, expected_main, expected_params):
+    main, params = parse_header(content, mode)
+    assert main == expected_main, f"Expected {expected_main}, but got {main}"
+    assert params == expected_params, f"Expected {expected_params}, but got {params}"


### PR DESCRIPTION
fix for #134 
introduces new get_parsed_header that hides the old `cgi`-dependenat implementation - which in turn got replaced by the new `email` package dependency
