### PR TITLE
fix #153 by including config folder path

### DIFF
--- a/sema/harvest/config_build.py
+++ b/sema/harvest/config_build.py
@@ -327,7 +327,9 @@ class ConfigBuilder:
         return [
             f.name
             for f in getMatchingGlobPaths(
-                includes=["*.yml", "*.yaml"], onlyFiles=True
+                self.config_files_folder,
+                includes=["*.yml", "*.yaml"],
+                onlyFiles=True,
             )
         ]
 

--- a/tests/harvest/test_config_build.py
+++ b/tests/harvest/test_config_build.py
@@ -2,10 +2,9 @@ import logging
 from pathlib import Path
 
 import pytest
-from rdflib import Graph
-from sema.harvest.config_build import ConfigBuilder, Config
-from sema.harvest.store import RDFStoreAccess
+
 from sema.harvest import Harvest
+from sema.harvest.config_build import ConfigBuilder
 
 log = logging.getLogger(__name__)
 

--- a/tests/harvest/test_config_build.py
+++ b/tests/harvest/test_config_build.py
@@ -1,0 +1,38 @@
+import logging
+from pathlib import Path
+
+import pytest
+from rdflib import Graph
+from sema.harvest.config_build import ConfigBuilder, Config
+from sema.harvest.store import RDFStoreAccess
+from sema.harvest import Harvest
+
+log = logging.getLogger(__name__)
+
+TEST_FOLDER = Path(__file__).parent
+TEST_Path: Path = TEST_FOLDER / "scenarios"
+CONFIGS = TEST_Path / "config"
+
+
+@pytest.mark.usefixtures("store_info_sets")
+def test_files_folder(store_info_sets: tuple) -> None:
+    for store in store_info_sets:
+        harvest = Harvest(str(CONFIGS), store)
+        # get the rdf store access
+        rdf_store_access = harvest.target_store
+        config_builder = ConfigBuilder(rdf_store_access, str(CONFIGS))
+        files = config_builder._files_folder()
+        assert isinstance(files, list)
+        assert len(files) > 0
+
+
+@pytest.mark.usefixtures("store_info_sets")
+def test_files_folder_invalid_path(store_info_sets: tuple) -> None:
+    for store in store_info_sets:
+        harvest = Harvest(str(CONFIGS), store)
+        # get the rdf store access
+        rdf_store_access = harvest.target_store
+        config_builder = ConfigBuilder(rdf_store_access, "invalid_path")
+        files = config_builder._files_folder()
+        assert isinstance(files, list)
+        assert len(files) == 0


### PR DESCRIPTION
the argument of root path was not given in the sema.harvest implementation.  This self.config_files_fodler variabl was added again so this path is now present again.

for the testing 2 were written to test a "correct" folder for which the _files_folder() would find files ending with *yml | *yaml and one which would result in an invalid path with no files found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the configuration file detection process to focus exclusively on the designated folder, providing more precise and predictable configuration loading.

- **Tests**
  - Added tests to validate the system’s behavior with both valid and invalid configuration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->