### PR TITLE
Small changes to add support for binary octet streams

### DIFF
--- a/sema/discovery/discovery.py
+++ b/sema/discovery/discovery.py
@@ -128,10 +128,11 @@ class Discovery(ServiceBase):
 
     def _add_triples_from_text(self, content, mimetype, source_url):
         if mimetype not in self.SUPPORTED_MIMETYPES:
-            return False
-        # else
+            log.debug(f"mimetype {mimetype} not supported for {source_url=}")
+            # return False
         EXTRA_FORMATS = {
             "application/octet-stream": "turtle",
+            "binary/octet-stream": "turtle",  # added for s3
             "application/json": "json-ld",
         }
         format = mime_to_format(mimetype) or EXTRA_FORMATS.get(mimetype, None)

--- a/tests/data/localhost_http_documentroot/s3_bucket
+++ b/tests/data/localhost_http_documentroot/s3_bucket
@@ -1,0 +1,124 @@
+     @prefix : <http://xmlns.com/foaf/0.1/> .
+    @prefix B: <https://www.w3.org/People/Berners-Lee/> .
+    @prefix Be: <./> .
+    @prefix Pub: <https://timbl.com/timbl/Public/> .
+    @prefix blog: <http://dig.csail.mit.edu/breadcrumbs/blog/> .
+    @prefix card: <https://www.w3.org/People/Berners-Lee/card#> .
+    @prefix cc: <http://creativecommons.org/ns#> .
+    @prefix cert: <http://www.w3.org/ns/auth/cert#> .
+    @prefix con: <http://www.w3.org/2000/10/swap/pim/contact#> .
+    @prefix dc: <http://purl.org/dc/elements/1.1/> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix doap: <http://usefulinc.com/ns/doap#> .
+    @prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+    @prefix ldp: <http://www.w3.org/ns/ldp#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix s: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix schema: <http://schema.org/> .
+    @prefix sioc: <http://rdfs.org/sioc/ns#> .
+    @prefix solid: <http://www.w3.org/ns/solid/terms#> .
+    @prefix space: <http://www.w3.org/ns/pim/space#> .
+    @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+    @prefix w3c: <http://www.w3.org/data#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    
+    <../../DesignIssues/Overview.html>     dc:title "Design Issues for the World Wide Web";
+         :maker card:i .
+    
+    <>     rdf:type :PersonalProfileDocument;
+         cc:license <http://creativecommons.org/licenses/by-nc/3.0/>;
+         dc:title "Tim Berners-Lee's FOAF file";
+         :maker card:i;
+         :primaryTopic card:i .
+    
+    <#i>     cert:key  [
+             rdf:type cert:RSAPublicKey;
+             cert:exponent 65537;
+             cert:modulus "ebe99c737bd3670239600547e5e2eb1d1497da39947b6576c3c44ffeca32cf0f2f7cbee3c47001278a90fc7fc5bcf292f741eb1fcd6bbe7f90650afb519cf13e81b2bffc6e02063ee5a55781d420b1dfaf61c15758480e66d47fb0dcb5fa7b9f7f1052e5ccbd01beee9553c3b6b51f4daf1fce991294cd09a3d1d636bc6c7656e4455d0aff06daec740ed0084aa6866fcae1359de61cc12dbe37c8fa42e977c6e727a8258bb9a3f265b27e3766fe0697f6aa0bcc81c3f026e387bd7bbc81580dc1853af2daa099186a9f59da526474ef6ec0a3d84cf400be3261b6b649dea1f78184862d34d685d2d587f09acc14cd8e578fdd2283387821296f0af39b8d8845"^^xsd:hexBinary ] .
+    
+    <http://dig.csail.mit.edu/2005/ajar/ajaw/data#Tabulator>     doap:developer card:i .
+    
+    <http://dig.csail.mit.edu/2007/01/camp/data#course>     :maker card:i .
+    
+    blog:4     dc:title "timbl's blog on DIG";
+         s:seeAlso <http://dig.csail.mit.edu/breadcrumbs/blog/feed/4>;
+         :maker card:i .
+    
+    <http://dig.csail.mit.edu/data#DIG>     :member card:i .
+    
+    <http://wiki.ontoworld.org/index.php/_IRW2006>     dc:title "Identity, Reference and the Web workshop 2006";
+         con:participant card:i .
+    
+    <http://www.ecs.soton.ac.uk/~dt2/dlstuff/www2006_data#panel-panelk01>     s:label "The Next Wave of the Web (Plenary Panel)";
+         con:participant card:i .
+    
+    <http://www.w3.org/2000/10/swap/data#Cwm>     doap:developer card:i .
+    
+    <http://www.w3.org/2011/Talks/0331-hyderabad-tbl/data#talk>     dct:title "Designing the Web for an Open Society";
+         :maker card:i .
+    
+    w3c:W3C     :member card:i .
+    
+    <https://timbl.com/timbl/Public/friends.ttl>     rdf:type :PersonalProfileDocument;
+         cc:license <http://creativecommons.org/licenses/by-nc/3.0/>;
+         dc:title "Tim Berners-Lee's editable profile";
+         :maker card:i;
+         :primaryTopic card:i .
+    
+    card:i     rdf:type con:Male,
+                :Person;
+         sioc:avatar <images/timbl-image-by-Coz-cropped.jpg>;
+         schema:owns <https://timblbot.inrupt.net/profile/card#me>;
+         s:label "Tim Berners-Lee";
+         s:seeAlso <https://timbl.com/timbl/Public/friends.ttl>;
+         con:assistant card:amy;
+         con:homePage Be:;
+         con:office  [
+             con:address  [
+                 con:city "Cambridge";
+                 con:country "USA";
+                 con:postalCode "02139";
+                 con:street "32 Vassar Street";
+                 con:street2 "MIT CSAIL Building 32" ];
+             geo:location  [
+                 geo:lat "42.361860";
+                 geo:long "-71.091840" ] ];
+         con:preferredURI "https://www.w3.org/People/Berners-Lee/card#i";
+         con:publicHomePage Be:;
+         vcard:fn "Tim Berners-Lee";
+         vcard:hasAddress  [
+             rdf:type vcard:Work;
+             vcard:locality "Cambridge";
+             vcard:postal-code "02139";
+             vcard:region "MA";
+             vcard:street-address "32 Vassar Street" ];
+         ldp:inbox Pub:Inbox;
+         space:preferencesFile <https://timbl.com/timbl/Data/preferences.n3>;
+         space:storage Pub:,
+                <https://timbl.inrupt.net/>,
+                <https://timbl.solid.community/>;
+         solid:editableProfile <https://timbl.com/timbl/Public/friends.ttl>;
+         solid:oidcIssuer <https://timbl.com>;
+         solid:profileBackgroundColor "#ffffff";
+         solid:profileHighlightColor "#00467E";
+         solid:publicTypeIndex <https://timbl.com/timbl/Public/PublicTypeIndex.ttl>;
+         :account <http://en.wikipedia.org/wiki/User:Timbl>,
+                <http://twitter.com/timberners_lee>,
+                <http://www.reddit.com/user/timbl/>;
+         :based_near  [
+             geo:lat "42.361860";
+             geo:long "-71.091840" ];
+         :family_name "Berners-Lee";
+         :givenname "Timothy";
+         :homepage B:;
+         :img <https://www.w3.org/Press/Stock/Berners-Lee/2001-europaeum-eighth.jpg>;
+         :mbox <mailto:timbl@w3.org>;
+         :mbox_sha1sum "965c47c5a70db7407210cef6e4e6f5374a525c5c";
+         :name "Timothy Berners-Lee";
+         :nick "TimBL",
+                "timbl";
+         :openid B:;
+         :title "Sir";
+         :weblog blog:4;
+         :workplaceHomepage <https://www.w3.org/> .
+    

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -20,6 +20,7 @@ HTTPD_EXTENSION_MAP: Dict[str, str] = {
     ".jsonld": "application/ld+json",
     ".ttl": "text/turtle",
     ".html": "text/html",
+    "": "binary/octet-stream",
 }
 
 # Update DIRECT_CASES to use local URIs with a domain
@@ -43,6 +44,11 @@ DIRECT_CASES: List[Tuple[str, str, int]] = [
         "rocrate.html",
         "application/json",
         532,
+    ),
+    (
+        "s3_bucket",
+        "text/turtle",
+        86,
     ),
 ]
 


### PR DESCRIPTION
This was done to be able to ingest s3 url for emobon , example:
https://s3.mesocentre.uca.fr/mgf-data-products/files/md5/17/5a4470423c8544fd31cae541003019

This change however suggests from our side that every binary octet stream will be treated as if it as a turtle file.
