### PR TITLE
fix(#206): switch default scheme to http for schema.org in cleaning

### DIFF
--- a/sema/commons/clean/clean.py
+++ b/sema/commons/clean/clean.py
@@ -110,7 +110,7 @@ clean_uri_node.level = Level.Node
 def normalise_scheme_str(
     uri: str,
     domain: str | None = "schema.org",
-    to_scheme: str | None = "https",
+    to_scheme: str | None = "http",
 ) -> str:
     # check uri matches ^https?://«domain».*
     # if not return input, else
@@ -124,7 +124,7 @@ def normalise_scheme_str(
 def normalise_scheme_node(
     ref: URIRef | BNode | Literal,
     domain: str | None = "schema.org",
-    to_scheme: str | None = "https",
+    to_scheme: str | None = "http",
 ) -> URIRef | BNode | Literal:
     log.debug("normalise_scheme_node called")
     if not isinstance(ref, URIRef):

--- a/tests/commons/clean/test_cleaning.py
+++ b/tests/commons/clean/test_cleaning.py
@@ -160,10 +160,10 @@ def test_normalise_scheme_node():
     http_uri = "http://schema.org/test"
     https_uri = "https://schema.org/test"
 
-    assert https_uri == normalise_scheme_str(http_uri)
-    assert https_uri == normalise_scheme_str(https_uri)
-    assert https_uri == str(normalise_scheme_node(URIRef(http_uri)))
-    assert https_uri == str(normalise_scheme_node(URIRef(https_uri)))
+    assert http_uri == normalise_scheme_str(http_uri)
+    assert http_uri == normalise_scheme_str(https_uri)
+    assert http_uri == str(normalise_scheme_node(URIRef(http_uri)))
+    assert http_uri == str(normalise_scheme_node(URIRef(https_uri)))
 
     domain = "example.org"
     http_domain = f"http://{domain}/tester"
@@ -330,7 +330,7 @@ def test_clean_chain():
                 uri = str(n)
                 assert check_valid_uri(uri)
                 if ("schema.org") in uri:
-                    assert uri.startswith("https://")
+                    assert uri.startswith("http://")
                 continue
             # else
             count_other += 1

--- a/tests/harvest/test_scenarios.py
+++ b/tests/harvest/test_scenarios.py
@@ -78,7 +78,7 @@ def netto_triples_for_store_info_set(
 
 def graphs_in_execution_report(rdfstore: RDFStoreAccess):
     sparql = """
-    PREFIX schema: <https://schema.org/>
+    PREFIX schema: <http://schema.org/>
     PREFIX void: <http://rdfs.org/ns/void#>
     SELECT ?s ?contentUrl ?triples
     WHERE {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Schema.org URI normalization now defaults to the `http://` scheme instead of `https://`.
  * Cleaning and execution-report processing consistently recognize `http://schema.org/` URIs.

* **Tests**
  * Updated validation and cleaning checks to reflect the new `http://` normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->